### PR TITLE
user should be able to read through the history

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,6 +1,6 @@
 define(['jquery', './base/gumhelper', './base/videoShooter'],
   function($, gumHelper, VideoShooter) {
-//  'use strict';
+  'use strict';
 
   var html = $('html');
   var body = $('body');


### PR DESCRIPTION
it works the same way as the terminal:
the bottom is sticky. If the user can see the bottom of the last message,
scroll to see it, but, if they have scrolled up to read through the history,
do not scroll, because it makes reading difficult.
