### PR TITLE
eliminated the 'ghost border' from the emojis when added to chatList

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -16,7 +16,7 @@ define(['jquery', './base/gumhelper', './base/videoShooter'],
   var CHAT_LIMIT = 35;
 
   emojify.setConfig({
-    emojify_tag_type: 'img',
+    emojify_tag_type: 'div',
     emoticons_enabled: true,
     people_enabled: true,
     nature_enabled: true,


### PR DESCRIPTION
The "ghost border" on the emojis were happening due to a rendering "bug" (if you can call it a bug) that put a border around an image with a background image. Changed the emoji tag to a div, solved the problem.
