### PR TITLE
let's scroll: part deux

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -151,7 +151,7 @@ h1 {
     margin-bottom: 1px;
     max-height: 250px;
     width: 100%;
-    overflow-y: scroll auto;
+    overflow-y: auto;
 }
 
 .chats li:nth-child(odd) {


### PR DESCRIPTION
`overflow-y: scroll auto` is a completely wrong way to write `overflow-y: auto`

[mdn overflow docs](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow)

(i guess i've use it for so long because it works: facepalm)
