### PR TITLE
Refactor linkify code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,9 @@ module.exports = function(grunt) {
           'public/stylesheets/main-min.css': ['public/stylesheets/main.css']
         }
       }
+    },
+    nodeunit: {
+      files: ["tests/**/*.js"],
     }
   });
 
@@ -43,6 +46,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
+  grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
   grunt.registerTask('default', ['copy', 'cssmin', 'requirejs', 'concat']);
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "meatspace-publico": "0.0.3",
     "gravatar": "1.0.6",
     "gumhelper": "0.0.3",
-    "socket.io": ">= 0.9.16"
+    "socket.io": ">= 0.9.16",
+    "requirejs": "~2.1.9",
+    "amdefine": "~0.1.0"
   },
   "devDependencies": {
     "grunt": ">= 0.4.x",
@@ -29,6 +31,7 @@
     "grunt-contrib-requirejs": ">= 0.4.0",
     "grunt-contrib-cssmin": ">= 0.4.1",
     "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-nodeunit": ">= 0.2.2",
     "nodemon": "*"
   }
 }

--- a/public/javascripts/config.js
+++ b/public/javascripts/config.js
@@ -3,7 +3,8 @@ requirejs.config({
   paths: {
     'jquery': 'lib/jquery',
     'Animated_GIF': 'lib/Animated_GIF/Animated_GIF',
-    'GifWriter': 'lib/Animated_GIF/omggif'
+    'GifWriter': 'lib/Animated_GIF/omggif',
+    'linkify': 'lib/linkify'
   },
   shim: {
     'jquery': {

--- a/public/javascripts/lib/linkify.js
+++ b/public/javascripts/lib/linkify.js
@@ -1,0 +1,86 @@
+var define = typeof define !== 'function' ?
+              require('amdefine')(module) : define;
+
+define([], function() {
+  var linkables = {
+    url: {
+      pattern: /(https?:\/\/)?((?:\.?[-\w]){1,256})(\.\w{1,10})(?::[0-9]{1,5})?(?:\.?\/(?:[^\s.,?:;!]|[.,?:;!](?!\s|$)){0,2048})?/gim,
+      transformer: function(match) {
+        var href = '';
+        var text = '';
+
+        if (match[1] === undefined) {
+          href += 'http://';
+        }
+
+        if (match[0].indexOf('(') === -1 && match[0].slice(-1) === ')') {
+          match[0] = match[0].slice(0, -1);
+        }
+
+        href += match[0];
+        text += match[0];
+
+        return template(href, text);
+      }
+    },
+    twitter: {
+      pattern: /@(\w{1,20})/g,
+      transformer: function(match) {
+        var handle = match[1];
+
+        if (!handle) {
+          return null;
+        }
+
+        return template('https://twitter.com/' + handle, match[0]);
+      }
+    },
+    reddit: {
+      pattern: /\/r\/(\w+)/g,
+      transformer: function(match) {
+        var subreddit = match[1];
+
+        if (!subreddit) {
+          return null;
+        }
+
+        return template('http://www.reddit.com/r/' + subreddit, match[0]);
+      }
+    }
+  };
+
+  var types = Object.keys(linkables);
+
+  function template(href, text) {
+    return '<a href="' + href + '" target="_blank">' + text + '</a>';
+  }
+
+  function linkify(text) {
+    var replacements = [];
+
+    types.forEach(function(type) {
+      var pattern = linkables[type].pattern;
+      var transformer = linkables[type].transformer;
+      var match, replace;
+
+      while ((match = pattern.exec(text))) {
+        replace = transformer(match);
+
+        if (replace !== null) {
+          replacements.push({
+            search: match[0],
+            replace: replace
+          });
+        }
+      }
+    });
+
+    replacements.forEach(function(r) {
+      text = text.replace(r.search, r.replace);
+    });
+
+    return text;
+  }
+
+  return linkify;
+});

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,5 +1,5 @@
-define(['jquery', './base/gumhelper', './base/videoShooter'],
-  function($, gumHelper, VideoShooter) {
+define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter'],
+  function($, linkify, gumHelper, VideoShooter) {
   'use strict';
 
   var html = $('html');
@@ -24,57 +24,6 @@ define(['jquery', './base/gumhelper', './base/videoShooter'],
     places_enabled: true,
     symbols_enabled: true
   });
-
-  var linkify = function (text) {
-    var linkHtml = function(href, text) {
-      return '<a href="' + href + '" target="_blank">' + text + '</a>';
-    };
-
-    var regexps = {};
-    regexps.url = /\b((?:https?:|www\.)\S+)/g;
-    regexps.twitter = /(\W?)@(\w{1,20})/g;
-    regexps.reddit = /(\W?)\/r\/(\w+)/g;
-
-    var funs = {};
-
-    funs.url = function(match, link) {
-      if (link.substr(0, 3) == 'www') {
-        link = 'http://' + link;
-      }
-      return linkHtml(link, match);
-    };
-
-    funs.twitter = function(match, notWord, handle) {
-      if (handle && handle.length > 0) {
-        return notWord +
-          linkHtml('https://twitter.com/' + handle,
-                   '@' + handle);
-      }
-    };
-
-    funs.reddit = function(match, notWord, subreddit) {
-      if (subreddit && subreddit.length > 0) {
-        return notWord +
-          linkHtml('http://www.reddit.com/r/' + subreddit,
-                   '/r/' + subreddit);
-      }
-    };
-
-    var matched = false;
-
-    $.each(['url', 'twitter', 'reddit'], function (idx, key){
-      if (matched) return;
-
-      var regexp = regexps[key];
-
-      if (text.match(regexp)) {
-        matched = true;
-        text = text.replace(regexp, funs[key]);
-      }
-    });
-
-    return text;
-  };
 
   var renderChat = function (c) {
     var img = new Image();

--- a/tests/linkify_test.js
+++ b/tests/linkify_test.js
@@ -1,0 +1,108 @@
+var requirejs = require('requirejs');
+
+requirejs.config({
+  nodeRequire: require
+});
+
+var linkify = requirejs('../public/javascripts/lib/linkify');
+var tests = {};
+var valid, inline;
+
+valid = {
+  values: [
+    'http://www.example.org/',
+    'https://www.example.org',
+    'http://www.example.co.uk/',
+    'https://example.org',
+    'chat.meatspac.es',
+    '(chat.meatspac.es)',
+    'chat.meatspac.es.',
+    'chat.meatspac.es/channel',
+    'https://example.org./path/to/stuff',
+    'http://www.example.org:8080/',
+    'http://example.org:8080/',
+    'This is a link... example.org.',
+    'This is a link... example.org, take a look!',
+    '(This is a link... example.org)',
+    'Link: chat.meatspac.es/channel?',
+    'Link: chat.meatspac.es/channel:',
+    'Link: chat.meatspac.es/channel;',
+    'Link: chat.meatspac.es/channel!',
+    '(This is a link... chat.meatspac.es/channel)',
+    'This is a link... chat.meatspac.es/channel.',
+    'This is a link... chat.meatspac.es/channel, or not',
+    'http://example.com/channel/bar(parens)',
+    'http://example.com/comma,here/',
+    '@twitter',
+    '@a @b @c',
+    '@a @b @c',
+    '@a @b @c',
+    '/r/puppies'
+  ],
+
+  expects: [
+    '<a href="http://www.example.org/" target="_blank">http://www.example.org/</a>',
+    '<a href="https://www.example.org" target="_blank">https://www.example.org</a>',
+    '<a href="http://www.example.co.uk/" target="_blank">http://www.example.co.uk/</a>',
+    '<a href="https://example.org" target="_blank">https://example.org</a>',
+    '<a href="http://chat.meatspac.es" target="_blank">chat.meatspac.es</a>',
+    '<a href="http://chat.meatspac.es" target="_blank">chat.meatspac.es</a>',
+    '<a href="http://chat.meatspac.es" target="_blank">chat.meatspac.es</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="https://example.org./path/to/stuff" target="_blank">https://example.org./path/to/stuff</a>',
+    '<a href="http://www.example.org:8080/" target="_blank">http://www.example.org:8080/</a>',
+    '<a href="http://example.org:8080/" target="_blank">http://example.org:8080/</a>',
+    '<a href="http://example.org" target="_blank">example.org</a>',
+    '<a href="http://example.org" target="_blank">example.org</a>',
+    '<a href="http://example.org" target="_blank">example.org</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="http://chat.meatspac.es/channel" target="_blank">chat.meatspac.es/channel</a>',
+    '<a href="http://example.com/channel/bar(parens)" target="_blank">http://example.com/channel/bar(parens)</a>',
+    '<a href="http://example.com/comma,here/" target="_blank">http://example.com/comma,here/</a>',
+    '<a href="https://twitter.com/twitter" target="_blank">@twitter</a>',
+    '<a href="https://twitter.com/a" target="_blank">@a</a>',
+    '<a href="https://twitter.com/b" target="_blank">@b</a>',
+    '<a href="https://twitter.com/c" target="_blank">@c</a>',
+    '<a href="http://www.reddit.com/r/puppies" target="_blank">/r/puppies</a>'
+  ]
+};
+
+valid.values.forEach(function(value, i) {
+  tests[value] = function(test) {
+    test.ok(linkify(value).indexOf(valid.expects[i]) !== -1);
+    test.done();
+  };
+});
+
+inline = {
+  values: [
+    'An inline link, like example.com, is replaced inline',
+    'An inline link, like http://example.com, is replaced inline',
+    'An inline twitter handle, like @twitter, is replaced inline',
+    'An inline subreddit, like /r/puppies, is replaced inline',
+    'All linkables, ie. example.com, @twitter, and /r/puppies are replaced inline'
+  ],
+  expects: [
+    'An inline link, like <a href="http://example.com" target="_blank">example.com</a>, is replaced inline',
+    'An inline link, like <a href="http://example.com" target="_blank">http://example.com</a>, is replaced inline',
+    'An inline twitter handle, like <a href="https://twitter.com/twitter" target="_blank">@twitter</a>, is replaced inline',
+    'An inline subreddit, like <a href="http://www.reddit.com/r/puppies" target="_blank">/r/puppies</a>, is replaced inline',
+    'All linkables, ie. <a href="http://example.com" target="_blank">example.com</a>, <a href="https://twitter.com/twitter" target="_blank">@twitter</a>, and <a href="http://www.reddit.com/r/puppies" target="_blank">/r/puppies</a> are replaced inline'
+  ]
+};
+
+inline.values.forEach(function(value, i) {
+  tests[value] = function(test) {
+    test.equal(linkify(value), inline.expects[i]);
+    test.done();
+  };
+});
+
+
+module.exports = tests;
+


### PR DESCRIPTION
- mv public/javascripts/linkify.hs public/javascripts/lib/linkify.js
- Redefines linkify() as an AMD module
- Moves specific "link type" regexps and transformation out of linkify function to avoid re-allocation on every call
- Adds test cases for inline linkification (adapted from cases originally  written by by @gnarf under Apache License)
- Replacement operation in two steps
- Escape message contents
- New Dependencies:
  - requirejs (the node module)
  - amddefine
  - grunt-contrib-nodeunit

Master: 

![http://gyazo.com/4ae010cd27993988586256da6f528559.png](http://gyazo.com/4ae010cd27993988586256da6f528559.png)

Refactored:
![http://gyazo.com/1db4b1403341110eaf81e0aae7bc9046.png](http://gyazo.com/1db4b1403341110eaf81e0aae7bc9046.png)

Signed-off-by: Rick Waldron waldron.rick@gmail.com
