### PR TITLE
Add /me, linkify edition

### DIFF
--- a/public/javascripts/linkify.js
+++ b/public/javascripts/linkify.js
@@ -61,6 +61,12 @@ define([], function() {
 
         return template('http://www.reddit.com/r/' + subreddit, match[0]);
       }
+    },
+    me: {
+      pattern: /^\/me\s+/g,
+      transformer: function(match) {
+        return "* dudebro ";
+      }
     }
   };
 


### PR DESCRIPTION
replaces https://github.com/meatspaces/meatspace-chat/pull/46 - Updated for the new linkify change.

Note that linkify is a bit scary, as it just hangs if you use a regexp without /g
