### PR TITLE
Hide previous posts on mute after a small delay, and unmute on accidental mutes.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -154,6 +154,14 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
           $("li[data-fingerprint='" + fp + "']").hide();
         }
       }, 3000)
+    } else {
+      var i = mutedArr.indexOf(fp);
+
+      if (i != -1) {
+        mutedArr.splice(i, 1);
+        localStorage.setItem('muted', JSON.stringify(mutedArr));
+        self.text('mute');
+      }
     }
   });
 


### PR DESCRIPTION
Building on top of point9repeating's PR. Added a setTimeout prior to hiding all the previous post. You can unmute before their post goes away.
