### PR TITLE
Align add-chat form elements with chat timeline

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -156,16 +156,8 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
     gumHelper.startVideoStreaming(function errorCb() {
       disableVideoMode();
     }, function successCallback(stream, videoElement, width, height) {
-      videoElement.width = width / 5;
-      videoElement.height = height / 5;
       footer.prepend(videoElement);
       videoElement.play();
-
-      // set offset to video width if it isn't already set
-      if (addChatForm.css('left') === '0px') {
-        addChatForm.css('left', width / 5);
-      }
-
       videoShooter = new VideoShooter(videoElement);
       addChatForm.click();
     });

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -251,7 +251,7 @@ h1 {
     position: relative;
     width: 100%;
     margin-top: 43px;
-    padding-bottom: 78px;
+    padding-bottom: 83px;
 }
 
 .chats.lean {
@@ -331,7 +331,7 @@ ul li.on {
 }
 
 .message-content {
-    bottom: 0;
+    bottom: 14px;
     height: 50px;
     left: 0;
     position: absolute;
@@ -365,20 +365,23 @@ ul li.on {
     right: 0;
     bottom: 0;
     left: 0;
+    padding: 0 0 2px 3px;
 }
 
 #footer video {
     float: left;
+    width: 135px;
+    height: 101px;
 }
 
 #footer svg.progress {
     z-index: 99;
     opacity: 0;
-    width: 128px;
-    height: 96px;
+    width: 135px;
+    height: 101px;
     position: absolute;
-    bottom: 0;
-    left: 0;
+    bottom: 2px;
+    left: 3px;
 }
 
 #footer svg.progress.visible {
@@ -436,6 +439,6 @@ ul li.on {
     }
 
     .input {
-        width: 155px;
+        width: 145px;
     }
 }


### PR DESCRIPTION
The size of the video preview and its alignment didn't flow well with the chats above it. I've adjusted the sizing + spacing to parity the chat items.

Before:

![image](https://f.cloud.github.com/assets/406639/1567007/ee0c2f04-5097-11e3-8d8e-a0e0eb2ce7ca.png)

After:

![image](https://f.cloud.github.com/assets/406639/1567017/2046b778-5098-11e3-8b32-43089b5e9c38.png)

At 320px wide:

![screen shot 2013-11-18 at 12 56 18 pm](https://f.cloud.github.com/assets/406639/1567019/2c0956d8-5098-11e3-9f68-7dc0b850eb54.png)
