### PR TITLE
Hide offscreen anigifs to improve CPU performance

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "jquery": "2.0.0",
+    "jquery-waypoints": "2.0.3",
     "fingerprint": "0.5.0",
     "js-md5": "1.0.1",
     "animated-gif": "sole/Animated_GIF#f951066bd13c8af0e40877efeb1b27bfb7156699",

--- a/public/javascripts/config.js
+++ b/public/javascripts/config.js
@@ -6,7 +6,8 @@ requirejs.config({
     'GifWriter': 'lib/animated-gif/src/omggif',
     'fingerprint': 'lib/fingerprint/fingerprint',
     'linkify': 'linkify',
-    'md5': 'lib/js-md5/js/md5'
+    'md5': 'lib/js-md5/js/md5',
+    'waypoints': 'lib/jquery-waypoints/waypoints'
   },
   shim: {
     'jquery': {

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,4 +1,4 @@
-define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerprint', 'md5'],
+define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerprint', 'md5', 'waypoints'],
   function ($, linkify, gumHelper, VideoShooter, Fingerprint, md5) {
   'use strict';
 
@@ -38,6 +38,22 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
     if (window.liveDebug) {
       console.log.apply(console, arguments);
     }
+  };
+
+  var setupWaypoints = function (rawLi) {
+    var li = $(rawLi);
+    li.waypoint(function (direction) {
+      li.toggleClass('out-of-view', direction === 'down');
+    }, {
+      offset: function () {
+        return -li.height();
+      }
+    });
+    li.waypoint(function (direction) {
+      li.toggleClass('out-of-view', direction === 'up');
+    }, {
+      offset: '100%'
+    });
   };
 
   var renderChat = function (c) {
@@ -81,6 +97,7 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
           var follow = bottom < size + 50;
 
           chatList.append(li);
+          setupWaypoints(li);
           debug('Appended chat %s', c.chat.key);
 
           // if scrolled to bottom of window then scroll the new thing into view
@@ -88,7 +105,7 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
           if (follow) {
             var children = chatList.children();
             if (children.length > CHAT_LIMIT) {
-              children.first().remove();
+              children.first().waypoint('destroy').remove();
             }
 
             li.scrollIntoView();

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -338,6 +338,10 @@ input::-webkit-input-placeholder {
   top: 18px;
 }
 
+.chats .out-of-view img {
+    display: none;
+}
+
 .chats li p {
     color: #000;
     font-size: 1.35rem;


### PR DESCRIPTION
This commit aims to do the same thing as #59 but addresses the performance concerns brought up by @rwaldron.  In this version a class (`out-of-view`) is added to chat list items that are not in the viewport, and `img`s of out-of-view chats are set to `display:none` in CSS. This is done using [jQuery Waypoints](http://imakewebthings.com/jquery-waypoints). Waypoints takes care of these performance concerns by:
- Throttling the scroll event.
- During the throttled handler, not hitting the DOM. Instead for each element an integer value is cached and that is compared against the current scroll position during the throttled event.
- The DOM hits and calculations are done only at times when that value may change: a new chat is added or the window is resized.
- Resize recalculations are also throttled.
- The out-of-view class is considered on both the top edge and bottom edge of the viewport. I believe the previous pull only concerned itself with the top.
