### PR TITLE
Initial load via burst of socket messages, deprecate /get/chats

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -141,17 +141,6 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
     userId.val(md5(fingerprint + data.ip));
   });
 
-  $.get('/get/chats', function (data) {
-    if (data.chats.chats) {
-      debug("Rec'd %s chats from server", data.chats.chats.length);
-      data.chats.chats.forEach(function (chat) {
-        renderChat({
-          chat: chat
-        });
-      });
-    }
-  });
-
   if (navigator.getMedia) {
     svg = $('<svg class="progress" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 128 64" preserveAspectRatio="xMidYMid" hidden><path d="M0,0 " id="arc" fill="none" stroke="rgba(226,38,97,0.8)" /></svg>');
 


### PR DESCRIPTION
Upon loading Meatspace, perform the initial sync of recent chat messages via the existing web socket message emission rather than via a large GET. Messages stream in one by one through the socket instead of a large ~3.5MB payload. Note, this deprecates the `HTTP GET /get/chats` endpoint, so native clients will have to be updated.

The advantages of this are:
- Messages are streamed out one by one and start arriving immediately, providing a more snappy initial load instead of a huge loading delay and blank screen.
- Flatten both ways of receiving chat messages into one method, yielding less code.
- Finer-grained arrival of the initial messages means the CPU can yield to the UI during the initial transfer, helping weaker devices survive the first paint.
