### PR TITLE
Fix typerror during removal of chats when list reaches capacity

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -105,7 +105,7 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
           if (follow) {
             var children = chatList.children();
             if (children.length > CHAT_LIMIT) {
-              children.first().waypoint('destroy').remove();
+              children.first().remove().waypoint('destroy');
             }
 
             li.scrollIntoView();


### PR DESCRIPTION
A bug in #111. When there are enough chats that the 25 limit kicks in we were getting a TypeError because the `.waypoints('destroy')` call doesn't return the jQuery object for chaining. That's a bug in Waypoints I'll fix in the next release but in the meantime we can just switch up the order of `remove` and `waypoints('destroy')`.
