### PR TITLE
Don't activate the chat form on ctrl/alt key combos.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -292,8 +292,13 @@ define(['jquery', 'linkify', './base/gumhelper', './base/videoShooter', 'fingerp
   });
 
   $(document).on('keydown', function (event) {
-    if (!event.metaKey && event.target !== addChat[0]) {
+    if (!hasModifiersPressed(event) && event.target !== addChat[0]) {
       addChat.focus();
     }
   });
+
+  function hasModifiersPressed(event) {
+    // modifiers exclude shift since it's often used in normal typing
+    return (event.altKey || event.ctrlKey || event.metaKey);
+  }
 });


### PR DESCRIPTION
This change fixes copying messages via keyboard shortcuts on non-Mac
clients.
