### PR TITLE
README.md console commands copyable as a block.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 [![Build Status](https://travis-ci.org/meatspaces/meatspace-chat.png)](https://travis-ci.org/meatspaces/meatspace-chat)
 
 ## Setting up
-    > cp local.json-dist local.json
-    > cp clients.json-dist clients.json
-    > npm install
-    > npm -g install nodemon
-    > bower install
-    > npm run-script grunt build
-    > npm start
+    cp local.json-dist local.json
+    cp clients.json-dist clients.json
+    npm install
+    npm -g install nodemon
+    bower install
+    npm run-script grunt build
+    npm start
 
 ## Mute feature
 


### PR DESCRIPTION
Someone (@moneypenny) already did this at commit #0d1241b, but it was rolled back.
