### PR TITLE
Stop using Express' bodyParser middleware.

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -22,7 +22,8 @@ module.exports = function(app, configurations, express) {
     app.set('views', __dirname + '/views');
     app.set('view engine', 'jade');
     app.set('view options', { layout: false });
-    app.use(express.bodyParser());
+    app.use(express.json());
+    app.use(express.urlencoded());
     app.use(express.methodOverride());
     if (!process.env.NODE_ENV) {
       app.use(express.logger('dev'));


### PR DESCRIPTION
The bodyParser middleware is problematic/exploit-prone, and will
be removed in future versions of Express/connect. Since meatspace
has no file uploads anyway, this patch takes the simplest approach
of replacing it with the json and urlencoded middleware.

See http://andrewkelley.me/post/do-not-use-bodyparser-with-express-js.html
