### PR TITLE
Add timestamps to chat messages.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -58,6 +58,24 @@ define(['jquery', 'transform', './base/gumhelper', './base/videoShooter', 'finge
     });
   };
 
+  var padToTwoDigits = function (number) {
+    return number < 10 ? '0' + number : '' + number;
+  };
+
+  var getTimeString = function (date) {
+    var hours = date.getHours();
+    var minutes = date.getMinutes();
+    var isAM = true;
+    if (hours > 12) {
+      hours = hours - 12;
+      isAM = false;
+    } else if (hours === 12) {
+      isAM = false;
+    }
+
+    return padToTwoDigits(hours) + ':' + padToTwoDigits(minutes) + ' ' + (isAM ? 'AM' : 'PM');
+  };
+
   var renderChat = function (c) {
     debug("Rendering chat: key='%s' fingerprint='%s' message='%s' created='%s' imageMd5='%s'",
       c.chat.key,
@@ -92,6 +110,13 @@ define(['jquery', 'transform', './base/gumhelper', './base/videoShooter', 'finge
           message.textContent = c.chat.value.message;
           message.innerHTML = transform(message.innerHTML);
           li.appendChild(message);
+
+          var createdDate = new Date(c.chat.value.created);
+          var timestamp = document.createElement('time');
+          timestamp.setAttribute('datetime', createdDate.toISOString());
+          timestamp.textContent = getTimeString(createdDate);
+          timestamp.className = 'timestamp';
+          li.appendChild(timestamp);
 
           var size = addChat.is(":visible") ? addChat[0].getBoundingClientRect().bottom : $(window).innerHeight();
           var last = chatList[0].lastChild;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -389,6 +389,23 @@ input::-webkit-input-placeholder {
     color: #eee;
 }
 
+.chats li .timestamp {
+    font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+    border: 0;
+    color: #666;
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 300;
+    position: absolute;
+    right: 0;
+    top: 0;
+    padding: 8px;
+}
+
+.chats li:first-of-type .timestamp {
+    top: 18px;
+}
+
 .chats li p span {
     color: #70b4e4;
     font-size: 0.8rem;


### PR DESCRIPTION
This adds a visible timestamp to each message, styled similarly to how the Android app is.

Screenshot:
![screenshot](https://f.cloud.github.com/assets/360513/1712062/7f6eedd0-6167-11e3-867c-1dbda9ec485a.png)
