### PR TITLE
remove deprecated use of .toggle(); default menu to hidden

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -202,12 +202,6 @@ define(['jquery', 'transform', './base/gumhelper', './base/videoShooter', 'finge
     }
   });
 
-  menu.toggle(function () {
-    $(this).addClass('on');
-  }, function () {
-    $(this).removeClass('on');
-  });
-
   var checkArtStatus = function () {
     if (artwork) {
       body.addClass('art');

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -134,6 +134,7 @@ body > img {
 }
 
 .menu {
+    display: none;
     background-color: #e22661;
     border-bottom: 1px solide #111;
     border-left: 1px solide #111;


### PR DESCRIPTION
As mentioned on the API - http://api.jquery.com/toggle-event/, the use of `toggle` here is deprecated and removed in jQuery 2.0. I removed it and defaulted the menu to hidden. The toggle action for showing/hiding the menu is still there and functional as that is in a separate function.
