### PR TITLE
show favicon notifications for unread chat messages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
     "js-md5": "1.0.1",
     "animated-gif": "sole/Animated_GIF#1cfb9afc999bdcfc51526fcaa0cd60fdc5d58f4c",
     "requirejs": "2.1.5",
-    "momentjs": "~2.4.0"
+    "momentjs": "~2.4.0",
+    "favico.js": "~0.3.3"
   }
 }

--- a/public/javascripts/config.js
+++ b/public/javascripts/config.js
@@ -7,7 +7,8 @@ requirejs.config({
     'transform': 'transform',
     'md5': 'lib/js-md5/js/md5',
     'waypoints': 'lib/jquery-waypoints/waypoints',
-    'moment': 'lib/momentjs/moment'
+    'moment': 'lib/momentjs/moment',
+    'favico': 'lib/favico.js/favico'
   },
   shim: {
     'jquery': {


### PR DESCRIPTION
Firefox:
![screen shot 2013-12-17 at 8 55 55 pm](https://f.cloud.github.com/assets/1302888/1762386/72066246-66f2-11e3-894b-ce85c4e99eda.png)

Unfortunately Chrome half hides it with the camera record icon:
![screen shot 2013-12-17 at 8 56 36 pm](https://f.cloud.github.com/assets/1302888/1762392/9777977a-66f2-11e3-8c8c-fc21780e7ebe.png)

Uses the [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/Guide/User_experience/Using_the_Page_Visibility_API) and [favico.js](http://lab.ejci.net/favico.js/).

Worth adding?
