### PR TITLE
Add chat messages even when the image load fails.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -68,7 +68,7 @@ define(['jquery', 'transform', './base/gumhelper', './base/videoShooter', 'finge
 
     if (!isMuted(renderFP)) {
       var img = new Image();
-      img.onload = function () {
+      var onComplete = function () {
         // Don't want duplicates and don't want muted messages
         if (body.find('li[data-key="' + c.chat.key + '"]').length === 0 &&
             !isMuted(renderFP)) {
@@ -120,6 +120,9 @@ define(['jquery', 'transform', './base/gumhelper', './base/videoShooter', 'finge
           }
         }
       };
+
+      img.onload = onComplete;
+      img.onerror = onComplete;
       img.src = c.chat.value.media;
     }
   };


### PR DESCRIPTION
Some bots send images as URIs rather than base64, which can result in
them not loading properly, either due to dead links or HTTPS cert
problems. In such cases, I think its better to display the imageless
message anyway, instead of just having the client drop it entirely.
