### PR TITLE
Responsive Info Page tiles

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -69,12 +69,15 @@ body.info {
 .info .item {
     background-color: #fff;
     box-shadow: #ccc 1px 1px 4px;
-    float: left;
-    height: 310px;
+    box-sizing: border-box;
+    display: inline-block;
+    height: 330px;
     margin: 5px;
     padding: 10px;
     position: relative;
-    width: 275px;
+    text-align: start;
+    vertical-align: top;
+    width: 295px;
 }
 
 .artist-wrapper {
@@ -151,6 +154,7 @@ body > img {
     max-width: 960px;
     min-width: 280px;
     width: 100%;
+    text-align: center;
 }
 
 .infobox-wrapper {


### PR DESCRIPTION
`float` is basically the worst thing ever.

![screen shot 2013-12-20 at 5 38 59 pm](https://f.cloud.github.com/assets/200687/1794383/cf5e017e-69c7-11e3-95d2-5e154e76b902.png)
![screen shot 2013-12-20 at 5 39 07 pm](https://f.cloud.github.com/assets/200687/1794380/cf468d14-69c7-11e3-92d9-4facacbbdc9f.png)
![screen shot 2013-12-20 at 5 39 11 pm](https://f.cloud.github.com/assets/200687/1794381/cf50fb00-69c7-11e3-8841-f068d838104b.png)
![screen shot 2013-12-20 at 5 39 15 pm](https://f.cloud.github.com/assets/200687/1794382/cf5d8df2-69c7-11e3-9f79-efd83071771f.png)
