### PR TITLE
Clear mutedArr when localStorage gets cleared.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -274,6 +274,7 @@ define(['jquery', 'transform', 'gumhelper', './base/videoShooter', 'fingerprint'
   body.on('click', '#unmute', function (ev) {
     debug('clearing mutes');
     localStorage.clear();
+    mutedArr = [];
   });
 
   addChatForm.on('keydown', function (ev) {


### PR DESCRIPTION
This keeps mutedArr in sync with localStorage, whereas previously users would have had to refresh the page to actually unmute people. Not sure how this went unnoticed for so long, oh well :smile: 
