### PR TITLE
Update doctype declaration to undeprecated form.

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   head
     title Meatspace chat: your 2 seconds of fame.


### PR DESCRIPTION
The latest version of Jade (installed on npm update/fresh npm install) breaks with the `!!!` form, which sucks for people trying to start up a meatspace now without much knowledge of node stuff :cry:
