### PR TITLE
Remove all the messages for a fingerprint when muted.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -241,7 +241,12 @@ define(['jquery', 'transform', 'gumhelper', './base/videoShooter', 'fingerprint'
       debug('Muting %s', fp);
       mutedArr.push(fp);
       localStorage.setItem('muted', JSON.stringify(mutedArr));
-      self.text('muted!');
+      var userMessages = $('.chats li[data-action="chat-message"]').filter(function() {
+        // using filter because we have no guarantee of fingerprint formatting, and if we tried to
+        // use an attribute selector, it could be XSS'd to some extent
+        return $(this).data('fingerprint') === fp;
+      });
+      userMessages.remove().waypoint('destroy');
     }
   });
 


### PR DESCRIPTION
I think this is a better behavior for things you don't want to see
(e.g. penises). In the future we should probably add some sort of undo
function for the last mute (accidental mutes seem to happen a lot), in
which case we might need to rethink the removal (keep the muted chats
somewhere so we can bring them back, perhaps?).
