### PR TITLE
Remove as many chats as necessary to get under the limit.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -150,8 +150,8 @@ define(['jquery', 'transform', 'gumhelper', './base/videoShooter', 'fingerprint'
           // otherwise, you are reading the history... allow user to scroll up.
           if (follow) {
             var children = chatList.children();
-            if (children.length > CHAT_LIMIT) {
-              children.first().remove().waypoint('destroy');
+            for (var i = 0, length = children.length; length > CHAT_LIMIT; length --, i ++) {
+              children.eq(i).remove().waypoint('destroy');
             }
 
             li.scrollIntoView();


### PR DESCRIPTION
Before, if you scrolled up in an active meatspace, you could end up
with a large number of chats in your buffer. When a new chat came in,
only the top one would be removed, leaving you with an equilibrium
potentially much higher than the actual limit.

With this change, when a chat comes in and a user is scrolled to the
bottom, all of the chats above CHAT_LIMIT will be removed, instead of
just the top one.
