### PR TITLE
Fix the other deprecated doctypes.

### DIFF
--- a/views/default_layout.jade
+++ b/views/default_layout.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   head
     title Meatspace chat: your 2 seconds of fame.

--- a/views/error_layout.jade
+++ b/views/error_layout.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html
   head
     title publico


### PR DESCRIPTION
Didn't notice these layouts when I was fixing the main page's doctype, so these ones are still causing Jade errors.
