### PR TITLE
Remove superficial side effects from videoshooter

### DIFF
--- a/public/javascripts/base/videoShooter.js
+++ b/public/javascripts/base/videoShooter.js
@@ -35,9 +35,6 @@ define(['Animated_GIF'], function (Animated_GIF) {
             // Ensure workers are freed-so we avoid bug #103 https://github.com/meatspaces/meatspace-chat/issues/103
             ag.destroy();
 
-            var img = document.createElement('img');
-            img.src = image;
-            document.body.appendChild(img);
             callback(image);
 
           });

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -318,7 +318,6 @@ define(['jquery', 'transform', 'gumhelper', './base/videoShooter', 'fingerprint'
             charCounter.text(CHAR_LIMIT);
             isPosting = false;
             addChatBlocker.addClass('hidden');
-            body.find('> img').remove();
           });
         }, 10, 0.2, function (captureProgress) {
           progressCircleTo(captureProgress);


### PR DESCRIPTION
Videoshooter adds an image to the body which main later removes, but this image is never actually used for any other purpose. PR removes unused image code from recording and submission pipeline, removes side effects from videoshooter
