### PR TITLE
multiple stat endpoint support + moved stat topic to separate frame

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,10 +10,14 @@ var settings = require('./settings')(app, configurations, express);
 
 nconf.argv().env().file({ file: 'local.json' });
 
-// set up meatcounter publisher
-var meatcounter_addr = nconf.get('meatcounter_addr');
+// set up meatcounter publisher and connect
+// to endpoints
+var meatcounter_addrs = nconf.get('meatcounter_addrs');
 var zio = zmq.socket('pub');
-zio.connect(meatcounter_addr);
+for (var i=0; i<meatcounter_addrs.length; i++) {
+  console.log(meatcounter_addrs[i]);
+  zio.connect(meatcounter_addrs[i]);
+}
 
 var topic_in = nconf.get('meatcounter_inc_topic');
 var topic_out = nconf.get('meatcounter_out_topic');

--- a/local.json-dist
+++ b/local.json-dist
@@ -6,7 +6,7 @@
     "analyticsHost": "your domain without the protocol (e.g. someurl.com)",
     "logger": "./logger",
     "appId": "",
-    "meatcounter_addr" : "ipc:///tmp/meatcounter.ipc",
+    "meatcounter_addrs" : ["ipc:///tmp/meatcounter.ipc", "tcp://127.0.0.1:9999"],
     "meatcounter_inc_topic" : "meatspace.incoming",
     "meatcounter_out_topic" : "meatspace.outgoing"
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -25,8 +25,8 @@ module.exports = function (app, nconf, io, zio, topic_in, topic_out) {
   };
 
   var emitChat = function (socket, chat, zio, topic_out) {
-    var statmsg = topic_out.concat(JSON.stringify({ fingerprint: chat.value.fingerprint }));
-    zio.send(statmsg);
+    var statmsg = JSON.stringify({ epoch_ms: (new Date).getTime(), fingerprint: chat.value.fingerprint });
+    zio.send([topic_out, statmsg]);
     socket.emit('message', { chat: chat });
   };
 
@@ -64,9 +64,8 @@ module.exports = function (app, nconf, io, zio, topic_in, topic_out) {
         next(err);
       } else {
         try {
-          var payload = JSON.stringify({ fingerprint: fingerprint });
-          var statmsg = topic_in.concat(payload);
-          zio.send(statmsg);
+          var statmsg = JSON.stringify( { epoch_ms: (new Date).getTime(), fingerprint: fingerprint } );
+          zio.send([topic_in, statmsg]);
           emitChat(io.sockets, { key: c.key, value: c }, zio, topic_out);
           next(null, 'sent!');
         } catch (err) {


### PR DESCRIPTION
.The outgoing stats socket can now be configured to connect to multiple endpoints.  This allows connecting to local stats dumping tools as well as forwarding to an aggregation point if you want to collect stats from multiple meatspace instances.

The message topic has been moved to it's own message frame.

Simple node.js dumper:

var zmq = require('zmq'), sock = zmq.socket('sub');
sock.subscribe("");
sock.bindSync ('tcp://127.0.0.1:9999');

sock.on('message', function(topic, stat) {
    console.log('RECEIVED: topic: %s, stat: %s', topic.toString(), stat.toString());
});
