### PR TITLE
Fixes memory leak due to waypoint retained nodes

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -150,8 +150,11 @@ define(['jquery', './base/transform', 'gumhelper', './base/videoShooter', 'finge
           if (follow) {
             var children = chatList.children();
             var toRemove = children.length - CHAT_LIMIT;
+            var dyingNode;
             for (var i = 0; i < toRemove; i ++) {
-              children.eq(i).remove().waypoint('destroy');
+              dyingNode = children.eq(i);
+              dyingNode.waypoint('destroy');
+              dyingNode.remove();
             }
 
             if (toRemove > 1) {


### PR DESCRIPTION
Leak occurs when old chat `li`s are removed - while they are removed from the active DOM they are retained in memory. The following heap diff after two chat lines are removes shows the retention:

![meat_before](https://f.cloud.github.com/assets/900789/1916947/e8152de2-7d85-11e3-8cb4-47afb1456152.png)

Notice the +2 deltas.

Calling `node.remove()` before `.waypoint('destroy')` caused a memory leak since "waypoints" uses jQuery data to store the node's waypoint ids and `.remove()` clears all jQuery data. The result was that the call to `.waypoint('remove')` does nothing (since the ids are gone) and the waypoint internal node cache retains every li ever created in the session.

The fix is to reverse the order of the calls. The resulting heap diff under the same test after the fix shows the DOM nodes are being properly released:

![meat_after](https://f.cloud.github.com/assets/900789/1916961/3ac5d33e-7d86-11e3-8725-fd77f6f56388.png)

Notice the deltas are now 0. Also note the secondary effects - no additionally retained closures (!), Waypoints, and jQuery objects.

Unfortunately the waypoints API call to 'destroy' does not return the jQuery object and therefore cannot be chained, hence the added ugliness of the additional lines of code.  :facepunch: 
