### PR TITLE
Upgrade Waypoints, clean up destroy/remove chaining

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "jquery": "2.0.0",
-    "jquery-waypoints": "2.0.3",
+    "jquery-waypoints": "2.0.4",
     "fingerprint": "0.5.0",
     "js-md5": "1.0.1",
     "animated-gif": "sole/Animated_GIF#38c7e30965578591de0f9dbbc87829f9259fd289",

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -163,12 +163,9 @@ define(['jquery', './base/transform', 'gumhelper', './base/videoShooter', 'finge
           if (follow) {
             var children = chat.list.children();
             var toRemove = children.length - CHAT_LIMIT;
-            var dyingNode;
-            for (var i = 0; i < toRemove; i ++) {
-              dyingNode = children.eq(i);
-              dyingNode.waypoint('destroy');
-              dyingNode.remove();
-            }
+
+            toRemove = toRemove < 0 ? 0 : toRemove;
+            children.slice(0, toRemove).waypoint('destroy').remove();
 
             if (toRemove > 1) {
               // if we've removed more than one message, then the vertical
@@ -284,8 +281,7 @@ define(['jquery', './base/transform', 'gumhelper', './base/videoShooter', 'finge
         // formatting, and therefore cannot trust a string attribute selector.
         return this.dataset.fingerprint === fingerprint;
       });
-      messages.waypoint('destroy');
-      messages.remove();
+      messages.waypoint('destroy').remove();
 
       $.waypoints('refresh');
     }


### PR DESCRIPTION
@robharper fixed jQuery Waypoints not chaining the jQuery object when using the `'destroy'` method. This commit updates the version of jQuery Waypoints to 2.0.4 and cleans up the workarounds Rob implemented because of the lack of chaining.
