### PR TITLE
make the fonts suck less

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -48,6 +48,8 @@ table {
 html, body {
     height: 100%;
     position: relative;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
 body {


### PR DESCRIPTION
Makes the rendering better on a retina screen and makes it easier to read by combining letters when possible

Before:
![](https://i.cloudup.com/KM05pylVGz-3000x3000.png)

After:
![](https://i.cloudup.com/yThThBs7ym-3000x3000.png)
