### PR TITLE
Prompt user in order to retry accessing webcam on error.

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -251,7 +251,11 @@ define(['jquery', './base/transform', 'gumhelper', './base/videoShooter', 'finge
     var startStreaming = function () {
       gumHelper.startVideoStreaming(function (err, stream, videoElement, videoWidth, videoHeight) {
         if (err) {
-          disableVideoMode();
+          if (window.confirm('Access to your camera seems to be blocked. Retry?')) {
+            window.setTimeout(startStreaming, 500);
+          } else {
+            disableVideoMode();
+          }
           return;
         }
 


### PR DESCRIPTION
Ubuntu (and possibly other flavors of Linux) don't like multiple applications accessing the webcam at the same time.

I'm running Ubuntu 13.10 and in Chromium 33.0.1750.152 (and I suspect other versions and browsers), if another application is accessing my webcam, MeatSpace silently errors out after I give it access to my camera.

After debugging, the error message is coming from gumHelper.startVideoStreaming():
`getUserMedia cannot access the camera`

This PR simply prompts the user to retry, and waits 500ms before trying again. In this case, it is possible for the user to quit the application accessing the webcam and click 'retry' without having to refresh the page.

I could modify this small change to check the specific error message in order to prompt the user to retry gaining access to the user's webcam when it can't, but I'm not sure how best to approach that, as checking the message of the error seems fragile.

Feedback appreciated :)

:heart: :green_heart: :purple_heart: :heart: :green_heart: :purple_heart: :heart: :green_heart: :purple_heart: :heart: :green_heart: :purple_heart: :heart: :green_heart: :purple_heart: :heart: :green_heart: :purple_heart: :heart: :green_heart: :purple_heart: 
