### PR TITLE
Add a button in the menu to switch the camera

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -30,5 +30,6 @@
   "termsLink": "Terms and Conditions",
   "browserWarningString": "Your browser is not letting you have the full Meatspace experience!",
   "browserWarningSubtext": "You will be able to see other peoples chats, but unable to post your own. Consider trying one of the browsers below, or continue on and just watch!",
-  "okay": "Okay"
+  "okay": "Okay",
+  "switchCamera": "Switch camera"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -30,5 +30,6 @@
   "termsLink": "Terms and Conditions",
   "browserWarningString": "Tu navegador no te permite disfrutar al máximo de la experiencia Meatspace!",
   "browserWarningSubtext": "Considera utilizar uno de los siguientes navegadores, o continua como observador.",
-  "okay": "Ok"
+  "okay": "Ok",
+  "switchCamera": "Cambiar de cámara"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -30,5 +30,6 @@
   "termsLink": "Terms and Conditions",
   "browserWarningString": "Votre navigateur ne vous permet pas de profiter correctement de Meatspace !",
   "browserWarningSubtext": "Vous pourrez voir ce que disent les autres mais vous ne pourrez pas participer. Veuillez essayer l'un des autres navigateurs ci-dessous, ou continuez à profiter du spectacle.",
-  "okay": "Ok"
+  "okay": "Ok",
+  "switchCamera": "Changer la caméra"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -30,5 +30,6 @@
   "termsLink": "Terms and Conditions",
   "browserWarningString": "Ваш браузер не поддерживает полный опыт Meatspace!",
   "browserWarningSubtext": "Вы сможете увидеть чужие чаты, но не можете писать. Попробуйте один из браузеров в низу, или продолжайте просто смотреть!",
-  "okay": "Окай"
+  "okay": "Окай",
+  "switchCamera": "Switch camera"
 }

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -312,7 +312,7 @@ define(['jquery', './base/transform', 'gumhelper', './base/videoShooter', 'finge
     );
   };
 
-  body.on('click', '#unmute, #tnc-accept, #browser-warning-accept', function (ev) {
+  body.on('click', '#unmute, #tnc-accept, #browser-warning-accept, #switch-camera', function (ev) {
     if (ev.target.id === 'unmute') {
       debug('clearing mutes');
       localStorage.removeItem('muted');
@@ -331,6 +331,13 @@ define(['jquery', './base/transform', 'gumhelper', './base/videoShooter', 'finge
     if (ev.target.id === 'browser-warning-accept') {
       debug('acknowledging lack of rtc');
       browserWarning.removeClass('on');
+    }
+
+    if (ev.target.id === 'switch-camera') {
+      debug('switching camera');
+      gumHelper.stopVideoStreaming();
+      composer.videoHolder.empty();
+      startStreaming();
     }
   }).on('keydown', function (ev) {
     if (isFocusingKey(ev) && ev.target !== composer.message[0]) {

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -26,6 +26,8 @@ html
             li
               a#unmute(href='javascript:;')= t('unmute')
             li
+              a#switch-camera(href='javascript:;')= t('switchCamera')
+            li
               a(href='https://chat.meatspac.es') international
             li
               a(href='https://fr.meatspac.es') en français


### PR DESCRIPTION
This PR adds a simple button in the menu to allow you to switch the camera without reloading the page.
I think this feature is useful, especially on mobile.
