### PR TITLE
Mirror the video and gifs

### DIFF
--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -453,6 +453,7 @@ input::-webkit-input-placeholder {
 }
 
 #chat-container li img {
+    transform: scale(-1, 1);
     display: block;
     position: absolute;
     top: 0;
@@ -579,6 +580,7 @@ ul li.on {
 }
 
 #videoHolder video {
+    transform: scale(-1, 1);
     width: 135px;
     height: 101px;
 }


### PR DESCRIPTION
The current playback video does not act as a mirror while most of people expect that. This confuse them, especially when they want to move their head in a specific direction or point at something.

This PR adds a mirror effect to the playback video and the received gifs.
I strongly advise you to try the feature to see the difference ;)
