### PR TITLE
[fix] replace broken command in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you want to create a browser add-on or plugin feel free to do so and follow t
     npm install
     npm -g install nodemon
     bower install
-    npm run-script grunt build
+    npm run-script build
     npm start
 
 ## Create a Twitter Application for Meatspace


### PR DESCRIPTION
originally the instructions stating that one should run the command `npm run-script grunt build`.  As there is no npm script named grunt this results in a no-op.

It turns out the the build script is simply aliased to grunt, so it might be worth getting rid of this all together and asking the user to simply run grunt.
